### PR TITLE
Add simple_form datetime picker input class

### DIFF
--- a/lib/bootstrap-datetimepicker-rails/simple_form.rb
+++ b/lib/bootstrap-datetimepicker-rails/simple_form.rb
@@ -1,0 +1,1 @@
+require "bootstrap-datetimepicker-rails/simple_form/inputs/datetime_picker_input"

--- a/lib/bootstrap-datetimepicker-rails/simple_form/inputs/datetime_picker_input.rb
+++ b/lib/bootstrap-datetimepicker-rails/simple_form/inputs/datetime_picker_input.rb
@@ -1,0 +1,22 @@
+module SimpleForm
+  module Inputs
+    class DatetimePickerInput < StringInput
+      def input
+        value = object.send(attribute_name) if object.respond_to? attribute_name
+        input_html_options[:value] ||= value.strftime("%Y-%m-%d %H:%M") if value.present?
+
+        input_html_options[:type] = 'text'
+        input_html_options[:data] ||= {}
+        input_html_options[:data].merge!({ format: 'yyyy-MM-dd hh:mm' })
+
+        template.content_tag :div, class: 'input-append date', data: { behavior: 'datetime-picker'} do
+          input = super # leave StringInput do the real rendering
+          input += template.content_tag :span, class: 'add-on' do
+            template.content_tag :i, '', class: 'icon-calendar', data: { 'time-icon' => 'icon-time', 'date-icon' => 'icon-calendar' }
+          end
+          input
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi there. This is the datetime picker input class I am using along with the stuff you have put together. People would need to add a require if they want the simple form input that way it just kind of sits there if they don't. 

I have no idea how to test this. Any ideas? How about how it's actually done? It is kind of custom to our current app. 
