### PR TITLE
only call addClass/removeClass on icon when icon defined

### DIFF
--- a/vendor/assets/javascripts/bootstrap-datetimepicker.js
+++ b/vendor/assets/javascripts/bootstrap-datetimepicker.js
@@ -69,13 +69,13 @@
       if (this.pickTime) {
         if (icon && icon.length) this.timeIcon = icon.data('time-icon');
         if (!this.timeIcon) this.timeIcon = 'icon-time';
-        icon.addClass(this.timeIcon);
+        if (icon) icon.addClass(this.timeIcon);
       }
       if (this.pickDate) {
         if (icon && icon.length) this.dateIcon = icon.data('date-icon');
         if (!this.dateIcon) this.dateIcon = 'icon-calendar';
-        icon.removeClass(this.timeIcon);
-        icon.addClass(this.dateIcon);
+        if (icon) icon.removeClass(this.timeIcon);
+        if (icon) icon.addClass(this.dateIcon);
       }
       this.widget = $(getTemplate(this.timeIcon, options.pickDate, options.pickTime, options.pick12HourFormat, options.pickSeconds, options.collapse)).appendTo('body');
       this.minViewMode = options.minViewMode||this.$element.data('date-minviewmode')||0;


### PR DESCRIPTION
In certain instances, the icon was not being found and javascript was throwing an error "cannot call method addClass/removeClass of undefined".
